### PR TITLE
Remove Scaling From deck

### DIFF
--- a/usr/bin/deckscale
+++ b/usr/bin/deckscale
@@ -13,9 +13,7 @@ sleep 5
 # Steam deck screen
 if [[ ! -z $(edid-decode /sys/class/drm/card1-eDP-1/edid | grep 'ANX7530 U') ]]; then
 	/usr/bin/kscreen-doctor output.eDP.rotation.right
-	/usr/bin/kscreen-doctor output.eDP.scale.1
 	/usr/bin/kscreen-doctor output.eDP-1.rotation.right
-	/usr/bin/kscreen-doctor output.eDP-1.scale.1
 fi
 
 # GPD Win 4 screen


### PR DESCRIPTION
The decks screen is 800p. Any scaling causes things to look massive. SteamOS default scaling is 100% (No scaling)